### PR TITLE
Fix landing routes to have clean urls

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,8 @@
         "firebase.json",
         "**/.*",
         "**/node_modules/**"
-      ]
+      ],
+      "cleanUrls": true
     },
     {
       "target": "production",
@@ -17,6 +18,7 @@
         "**/.*",
         "**/node_modules/**"
       ],
+      "cleanUrls": true,
       "headers": [
         {
           "source": "**/*.@(js|jpg|jpeg|gif|png)",


### PR DESCRIPTION
Looks like navigating to `https://meow.coffee/projects` now 404's—previously this would take you to `https://meow.coffee/projects.html` and cleanly rewrite the url to not have the `.html` extension.

Per this PR, that feature is now an explicit option of firebase hosting.